### PR TITLE
Deprecate ep_mammoth — functionality now in Etherpad core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,15 @@
-![Publish Status](https://github.com/ether/ep_mammoth/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_mammoth/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_mammoth/actions/workflows/test-and-release.yml)
+# ep_mammoth — deprecated, now part of Etherpad core
 
-# Mammoth DocX import Etherpad plugin
-
-Tired of losing fidelity when importing those horrible Microsoft .docx files?  This plugin solves that. 
-
-# Don't ignore blank paragraphs
-
-Add the following to your settings.json
-
-```
-  "ep_mammoth":{
-    "ignoreEmptyParagraphs": false
-  }
-```
-
-## Installation
-
-Install from the Etherpad admin UI (**Admin → Manage Plugins**,
-search for `ep_mammoth` and click *Install*), or from the Etherpad
-root directory:
-
-```sh
-pnpm run plugins install ep_mammoth
-```
-
-> ⚠️ Don't run `npm i` / `npm install` yourself from the Etherpad
-> source tree — Etherpad tracks installed plugins through its own
-> plugin-manager, and hand-editing `package.json` can leave the
-> server unable to start.
-
-After installing, restart Etherpad.
+> **This plugin is no longer needed.** `.docx` import is built into
+> Etherpad and uses `mammoth` natively. See
+> [`src/node/utils/ImportDocxNative.ts`](https://github.com/ether/etherpad-lite/blob/main/src/node/utils/ImportDocxNative.ts)
+> in the Etherpad core repository.
+>
+> If you have `ep_mammoth` installed, you can uninstall it — Etherpad
+> will handle `.docx` imports without it. The previously recommended
+> `ep_mammoth.ignoreEmptyParagraphs: false` behaviour is the default
+> in core, so you can also remove that block from `settings.json`.
+>
+> This repository is archived and will receive no further updates.
+> Please file `.docx` import issues against
+> [ether/etherpad-lite](https://github.com/ether/etherpad-lite/issues).


### PR DESCRIPTION
## Summary
- Replace README with a deprecation notice — `.docx` import via `mammoth` is now built into Etherpad core (`src/node/utils/ImportDocxNative.ts`).
- Point users at `ether/etherpad-lite` for issues and confirm the repo will be archived.
- Note that core hardcodes `ignoreEmptyParagraphs: false` so the previous `ep_mammoth.ignoreEmptyParagraphs` block can be dropped from `settings.json`.

## Test plan
- [ ] README renders correctly on GitHub with the deprecation banner.
- [ ] After merge, archive `ether/ep_mammoth` via `gh repo archive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)